### PR TITLE
C3: UX & Polish — a11y, tokens, typo, skeletons

### DIFF
--- a/src/app/(parcours)/[parcours]/apprendre/[moduleId]/[activityId]/activity-client.tsx
+++ b/src/app/(parcours)/[parcours]/apprendre/[moduleId]/[activityId]/activity-client.tsx
@@ -84,8 +84,8 @@ export function ActivityClient({
     if (qcmFinished) {
       return (
         <div className="text-center py-8">
-          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-950/30">
-            <CheckCircle2 className="h-8 w-8 text-green-600" />
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-success/10">
+            <CheckCircle2 className="h-8 w-8 text-success" aria-hidden="true" />
           </div>
           <h2 className="text-xl font-bold">QCM terminé !</h2>
           <p className="mt-2 text-muted-foreground">
@@ -98,8 +98,8 @@ export function ActivityClient({
     return (
       <div>
         {previousProgress && previousProgress.score !== undefined && previousProgress.total ? (
-          <div className="mb-6 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950/20">
-            <p className="text-sm text-green-800 dark:text-green-200">
+          <div className="mb-6 rounded-lg border border-success/25 bg-success/10 p-4">
+            <p className="text-sm text-success-foreground">
               Déjà fait : {previousProgress.score}/{previousProgress.total} (
               {Math.round((previousProgress.score / previousProgress.total) * 100)}%)
             </p>
@@ -127,8 +127,8 @@ export function ActivityClient({
         {/* Completion section */}
         <div className="mt-8 flex flex-col items-center justify-center border-t pt-6">
           {activityCompleted ? (
-            <div className="flex items-center gap-2 text-green-600">
-              <CheckCircle2 className="h-5 w-5" />
+            <div className="flex items-center gap-2 text-success">
+              <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
               <span className="font-medium">Exercice terminé</span>
             </div>
           ) : (
@@ -137,7 +137,7 @@ export function ActivityClient({
                 Tu as fini cet exercice ?
               </p>
               <Button onClick={handleExerciseComplete} variant="outline">
-                <CheckCircle2 className="mr-2 h-4 w-4" />
+                <CheckCircle2 className="mr-2 h-4 w-4" aria-hidden="true" />
                 J&apos;ai compris
               </Button>
             </>

--- a/src/app/(parcours)/[parcours]/apprendre/[moduleId]/loading.tsx
+++ b/src/app/(parcours)/[parcours]/apprendre/[moduleId]/loading.tsx
@@ -1,7 +1,17 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
 export default function ModuleLoading() {
   return (
     <div className="flex h-full items-center justify-center">
-      <div className="text-muted-foreground">Chargement...</div>
+      <div className="w-full max-w-2xl space-y-6 px-4">
+        <Skeleton className="h-8 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+        <div className="space-y-3">
+          <Skeleton className="h-24 w-full rounded-lg" />
+          <Skeleton className="h-24 w-full rounded-lg" />
+          <Skeleton className="h-24 w-full rounded-lg" />
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/app/(parcours)/[parcours]/page.tsx
+++ b/src/app/(parcours)/[parcours]/page.tsx
@@ -42,7 +42,7 @@ export default async function ParcoursDashboardPage({ params }: PageProps) {
             <Button size="lg" asChild>
               <Link href={`/${parcours}/apprendre`}>
                 Continuer
-                <ArrowRight className="ml-2 h-4 w-4" />
+                <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
               </Link>
             </Button>
           </div>

--- a/src/app/(parcours)/[parcours]/reviser/reviser-client.tsx
+++ b/src/app/(parcours)/[parcours]/reviser/reviser-client.tsx
@@ -65,7 +65,7 @@ export function ReviserStats() {
       <Card>
         <CardContent className="flex items-center gap-4 py-4">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Trophy className="h-5 w-5 text-primary" />
+            <Trophy className="h-5 w-5 text-primary" aria-hidden="true" />
           </div>
           <div>
             <p className="tabular-nums text-2xl font-bold">{stats.completed}</p>
@@ -75,8 +75,8 @@ export function ReviserStats() {
       </Card>
       <Card>
         <CardContent className="flex items-center gap-4 py-4">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-green-100 dark:bg-green-900/20">
-            <GraduationCap className="h-5 w-5 text-green-600" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-success/10">
+            <GraduationCap className="h-5 w-5 text-success" aria-hidden="true" />
           </div>
           <div>
             <p className="tabular-nums text-2xl font-bold">{stats.avgScore}%</p>
@@ -86,8 +86,8 @@ export function ReviserStats() {
       </Card>
       <Card>
         <CardContent className="flex items-center gap-4 py-4">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 dark:bg-blue-900/20">
-            <Check className="h-5 w-5 text-blue-600" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-info/10">
+            <Check className="h-5 w-5 text-info" aria-hidden="true" />
           </div>
           <div>
             <p className="tabular-nums text-2xl font-bold">{stats.exercisesDone}</p>
@@ -169,16 +169,16 @@ export function SeriesListItem({ serie, activityIds, parcours }: SeriesListItemP
       <div
         className={`flex h-10 w-10 items-center justify-center rounded-lg ${
           isSerieComplete
-            ? 'bg-green-100 dark:bg-green-900/20'
+            ? 'bg-success/10'
             : 'bg-primary/10'
         }`}
       >
         {isSerieComplete ? (
-          <Check className="h-5 w-5 text-green-600" />
+          <Check className="h-5 w-5 text-success" aria-hidden="true" />
         ) : serieProgress.completed > 0 ? (
-          <RotateCcw className="h-5 w-5 text-primary" />
+          <RotateCcw className="h-5 w-5 text-primary" aria-hidden="true" />
         ) : (
-          <GraduationCap className="h-5 w-5 text-primary" />
+          <GraduationCap className="h-5 w-5 text-primary" aria-hidden="true" />
         )}
       </div>
 
@@ -186,7 +186,7 @@ export function SeriesListItem({ serie, activityIds, parcours }: SeriesListItemP
         <div className="flex items-center gap-2">
           <p className="font-medium">{serie.title}</p>
           {isSerieComplete && (
-            <Badge variant="default" className="bg-green-600 text-xs">
+            <Badge variant="default" className="bg-success text-xs">
               Terminé
             </Badge>
           )}
@@ -206,7 +206,7 @@ export function SeriesListItem({ serie, activityIds, parcours }: SeriesListItemP
             {getDifficultyLabel(serie.difficulty)}
           </Badge>
           <span className="flex items-center gap-1 text-xs text-muted-foreground">
-            <Clock className="h-3 w-3" />
+            <Clock className="h-3 w-3" aria-hidden="true" />
             {serie.estimatedMinutes} min
           </span>
           <span className="text-xs text-muted-foreground">
@@ -220,7 +220,7 @@ export function SeriesListItem({ serie, activityIds, parcours }: SeriesListItemP
         )}
       </div>
 
-      <ChevronRight className="h-5 w-5 text-muted-foreground" />
+      <ChevronRight className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
     </Link>
   )
 }

--- a/src/app/(parcours)/[parcours]/reviser/serie/[id]/layout.tsx
+++ b/src/app/(parcours)/[parcours]/reviser/serie/[id]/layout.tsx
@@ -28,7 +28,7 @@ export default async function SerieLayout({ children, params }: LayoutProps) {
   const activities = resolveSerieActivities(id)
 
   return (
-    <div className="flex h-[calc(100vh-3.5rem)]">
+    <div className="flex h-[calc(100svh-3.5rem)]">
       {/* Timeline Sidebar */}
       <SerieTimelineWrapper
         serieSlug={serie.slug}

--- a/src/app/(parcours)/[parcours]/reviser/serie/[id]/loading.tsx
+++ b/src/app/(parcours)/[parcours]/reviser/serie/[id]/loading.tsx
@@ -1,7 +1,17 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
 export default function SerieLoading() {
   return (
     <div className="flex h-full items-center justify-center">
-      <div className="text-muted-foreground">Chargement...</div>
+      <div className="w-full max-w-2xl space-y-6 px-4">
+        <Skeleton className="h-8 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+        <div className="space-y-3">
+          <Skeleton className="h-20 w-full rounded-lg" />
+          <Skeleton className="h-20 w-full rounded-lg" />
+          <Skeleton className="h-20 w-full rounded-lg" />
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/app/(parcours)/[parcours]/reviser/serie/[id]/play/serie-player.tsx
+++ b/src/app/(parcours)/[parcours]/reviser/serie/[id]/play/serie-player.tsx
@@ -50,7 +50,7 @@ export function SeriePlayer({ serieSlug, serieTitle, activities, parcours }: Ser
 
   if (!currentActivity) {
     return (
-      <div className="flex h-[calc(100vh-3.5rem)] items-center justify-center">
+      <div className="flex h-[calc(100svh-3.5rem)] items-center justify-center">
         <div className="text-center text-muted-foreground">
           <p className="text-lg font-medium">Activité non trouvée</p>
           <Button className="mt-4" asChild>
@@ -126,11 +126,11 @@ export function SeriePlayer({ serieSlug, serieTitle, activities, parcours }: Ser
     const previousProgress = getProgress(currentActivity.id)
 
     return (
-      <div className="flex h-[calc(100vh-3.5rem)] flex-col">
+      <div className="flex h-[calc(100svh-3.5rem)] flex-col">
         <header className="flex items-center gap-4 border-b px-4 py-3">
           <Button variant="ghost" size="icon" asChild>
             <Link href={`/${parcours}/reviser/serie/${serieSlug}`}>
-              <X className="h-5 w-5" />
+              <X className="h-5 w-5" aria-hidden="true" />
               <span className="sr-only">Quitter</span>
             </Link>
           </Button>
@@ -148,8 +148,8 @@ export function SeriePlayer({ serieSlug, serieTitle, activities, parcours }: Ser
         <div className="flex-1 overflow-auto">
           <div className="mx-auto max-w-3xl px-4 lg:px-6 py-6">
             {previousProgress && previousProgress.score !== undefined && previousProgress.total ? (
-              <div className="mb-6 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950/20">
-                <p className="text-sm text-green-800 dark:text-green-200">
+              <div className="mb-6 rounded-lg border border-success/25 bg-success/10 p-4">
+                <p className="text-sm text-success-foreground">
                   Déjà fait : {previousProgress.score}/{previousProgress.total} ({Math.round((previousProgress.score / previousProgress.total) * 100)}%)
                 </p>
               </div>
@@ -168,11 +168,11 @@ export function SeriePlayer({ serieSlug, serieTitle, activities, parcours }: Ser
 
   // Lessons and Exercises
   return (
-    <div className="flex h-[calc(100vh-3.5rem)] flex-col">
+    <div className="flex h-[calc(100svh-3.5rem)] flex-col">
       <header className="flex items-center gap-4 border-b px-4 py-3">
         <Button variant="ghost" size="icon" asChild>
           <Link href={`/${parcours}/reviser/serie/${serieSlug}`}>
-            <X className="h-5 w-5" />
+            <X className="h-5 w-5" aria-hidden="true" />
             <span className="sr-only">Quitter</span>
           </Link>
         </Button>
@@ -193,8 +193,8 @@ export function SeriePlayer({ serieSlug, serieTitle, activities, parcours }: Ser
             {getAtomTypeLabel(currentActivity.type)}
           </Badge>
           {activityCompleted && (
-            <Badge variant="default" className="bg-green-600 text-xs">
-              <CheckCircle2 className="mr-1 h-3 w-3" />
+            <Badge variant="default" className="bg-success text-xs">
+              <CheckCircle2 className="mr-1 h-3 w-3" aria-hidden="true" />
               Fait
             </Badge>
           )}
@@ -211,13 +211,13 @@ export function SeriePlayer({ serieSlug, serieTitle, activities, parcours }: Ser
           {currentActivity.type === 'exercise' && (
             <div className="mt-6 flex items-center justify-center">
               {activityCompleted ? (
-                <div className="flex items-center gap-2 text-green-600">
-                  <CheckCircle2 className="h-5 w-5" />
+                <div className="flex items-center gap-2 text-success">
+                  <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
                   <span className="font-medium">Exercice terminé</span>
                 </div>
               ) : (
                 <Button onClick={handleExerciseComplete} variant="outline">
-                  <CheckCircle2 className="mr-2 h-4 w-4" />
+                  <CheckCircle2 className="mr-2 h-4 w-4" aria-hidden="true" />
                   J&apos;ai compris
                 </Button>
               )}
@@ -228,19 +228,19 @@ export function SeriePlayer({ serieSlug, serieTitle, activities, parcours }: Ser
 
       <footer className="flex items-center justify-between border-t px-4 py-3">
         <Button variant="outline" onClick={handlePrevious} disabled={isFirst}>
-          <ArrowLeft className="mr-2 h-4 w-4" />
+          <ArrowLeft className="mr-2 h-4 w-4" aria-hidden="true" />
           Précédent
         </Button>
 
         {isLast ? (
           <Button onClick={handleFinish}>
             Terminer
-            <CheckCircle className="ml-2 h-4 w-4" />
+            <CheckCircle className="ml-2 h-4 w-4" aria-hidden="true" />
           </Button>
         ) : (
           <Button onClick={handleNext}>
             Suivant
-            <ArrowRight className="ml-2 h-4 w-4" />
+            <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
           </Button>
         )}
       </footer>

--- a/src/app/(parcours)/[parcours]/reviser/serie/[id]/result/page.tsx
+++ b/src/app/(parcours)/[parcours]/reviser/serie/[id]/result/page.tsx
@@ -32,8 +32,8 @@ export default async function SerieResultPage({ params }: PageProps) {
     <div className="mx-auto max-w-2xl px-4 lg:px-6">
       {/* Success Header */}
       <div className="mb-8 text-center">
-        <div className="mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
-          <Award className="h-10 w-10 text-green-600" aria-hidden="true" />
+        <div className="mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-success/10">
+          <Award className="h-10 w-10 text-success" aria-hidden="true" />
         </div>
         <h1 className="text-balance font-serif text-3xl font-semibold">Félicitations !</h1>
         <p className="mt-2 text-lg text-muted-foreground">
@@ -60,13 +60,13 @@ export default async function SerieResultPage({ params }: PageProps) {
       <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
         <Button variant="outline" asChild>
           <Link href={`/${parcours}/reviser/serie/${id}/play`}>
-            <RotateCcw className="mr-2 h-4 w-4" />
+            <RotateCcw className="mr-2 h-4 w-4" aria-hidden="true" />
             Refaire la série
           </Link>
         </Button>
         <Button asChild>
           <Link href={`/${parcours}/reviser`}>
-            <Home className="mr-2 h-4 w-4" />
+            <Home className="mr-2 h-4 w-4" aria-hidden="true" />
             Autres séries
           </Link>
         </Button>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -42,7 +42,7 @@ export function AppSidebar({ parcours, modules = [], ...props }: AppSidebarProps
             <SidebarMenuButton asChild size="lg">
               <Link href={parcours ? `/${parcours}` : '/'}>
                 <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-                  <BookOpen className="h-4 w-4" />
+                  <BookOpen className="h-4 w-4" aria-hidden="true" />
                 </div>
                 <div className="flex flex-col gap-0.5">
                   <span className="font-serif text-lg font-semibold leading-none">Learning</span>
@@ -64,7 +64,7 @@ export function AppSidebar({ parcours, modules = [], ...props }: AppSidebarProps
               <SidebarMenuItem>
                 <SidebarMenuButton asChild isActive={pathname === dashboardUrl}>
                   <Link href={dashboardUrl}>
-                    <Home className="h-4 w-4" />
+                    <Home className="h-4 w-4" aria-hidden="true" />
                     <span>Tableau de bord</span>
                   </Link>
                 </SidebarMenuButton>
@@ -75,7 +75,7 @@ export function AppSidebar({ parcours, modules = [], ...props }: AppSidebarProps
               <SidebarMenuItem>
                 <SidebarMenuButton asChild isActive={pathname.startsWith(reviserUrl)}>
                   <Link href={reviserUrl}>
-                    <Brain className="h-4 w-4" />
+                    <Brain className="h-4 w-4" aria-hidden="true" />
                     <span>Réviser</span>
                   </Link>
                 </SidebarMenuButton>

--- a/src/components/content/exercise-parts.tsx
+++ b/src/components/content/exercise-parts.tsx
@@ -23,12 +23,12 @@ export function Enonce({ children }: PartProps) {
 
 export function Solution({ children }: PartProps) {
   return (
-    <details className="not-prose mt-6 rounded-lg border border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20">
+    <details className="not-prose mt-6 rounded-lg border border-success/25 bg-success/10">
       <summary className="flex cursor-pointer select-none items-center gap-2 px-4 py-3 font-medium">
-        <CheckCircle className="h-5 w-5 text-green-600" aria-hidden="true" />
+        <CheckCircle className="h-5 w-5 text-success" aria-hidden="true" />
         Voir la solution
       </summary>
-      <div className="prose prose-stone dark:prose-invert max-w-none border-t border-green-200 px-4 py-4 dark:border-green-800">
+      <div className="prose prose-stone dark:prose-invert max-w-none border-t border-success/25 px-4 py-4">
         {children}
       </div>
     </details>
@@ -37,12 +37,12 @@ export function Solution({ children }: PartProps) {
 
 export function Methode({ children }: PartProps) {
   return (
-    <details className="not-prose mt-6 rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/20">
+    <details className="not-prose mt-6 rounded-lg border border-info/25 bg-info/10">
       <summary className="flex cursor-pointer select-none items-center gap-2 px-4 py-3 font-medium">
-        <BookOpen className="h-5 w-5 text-blue-600" aria-hidden="true" />
-        Methode
+        <BookOpen className="h-5 w-5 text-info" aria-hidden="true" />
+        Méthode
       </summary>
-      <div className="prose prose-stone dark:prose-invert max-w-none border-t border-blue-200 px-4 py-4 dark:border-blue-800">
+      <div className="prose prose-stone dark:prose-invert max-w-none border-t border-info/25 px-4 py-4">
         {children}
       </div>
     </details>
@@ -51,12 +51,12 @@ export function Methode({ children }: PartProps) {
 
 export function Hint({ children }: PartProps) {
   return (
-    <details className="not-prose mt-6 rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/20">
+    <details className="not-prose mt-6 rounded-lg border border-warning/25 bg-warning/10">
       <summary className="flex cursor-pointer select-none items-center gap-2 px-4 py-3 font-medium">
-        <Lightbulb className="h-5 w-5 text-amber-600" aria-hidden="true" />
+        <Lightbulb className="h-5 w-5 text-warning" aria-hidden="true" />
         Indice
       </summary>
-      <div className="prose prose-stone dark:prose-invert max-w-none border-t border-amber-200 px-4 py-4 dark:border-amber-800">
+      <div className="prose prose-stone dark:prose-invert max-w-none border-t border-warning/25 px-4 py-4">
         {children}
       </div>
     </details>
@@ -65,12 +65,12 @@ export function Hint({ children }: PartProps) {
 
 export function Erreurs({ children }: PartProps) {
   return (
-    <details className="not-prose mt-6 rounded-lg border border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950/20">
+    <details className="not-prose mt-6 rounded-lg border border-destructive/25 bg-destructive/10">
       <summary className="flex cursor-pointer select-none items-center gap-2 px-4 py-3 font-medium">
-        <AlertTriangle className="h-5 w-5 text-red-600" aria-hidden="true" />
+        <AlertTriangle className="h-5 w-5 text-destructive" aria-hidden="true" />
         Erreurs courantes
       </summary>
-      <div className="prose prose-stone dark:prose-invert max-w-none border-t border-red-200 px-4 py-4 dark:border-red-800">
+      <div className="prose prose-stone dark:prose-invert max-w-none border-t border-destructive/25 px-4 py-4">
         {children}
       </div>
     </details>

--- a/src/components/course-timeline.tsx
+++ b/src/components/course-timeline.tsx
@@ -227,7 +227,7 @@ function StepIndicator({
   if (activityProgress?.isCompleted && activityProgress?.isSuccess) {
     return (
       <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-foreground/10">
-        <Check className="h-3 w-3 text-foreground/50" />
+        <Check className="h-3 w-3 text-foreground/50" aria-hidden="true" />
       </span>
     )
   }
@@ -235,7 +235,7 @@ function StepIndicator({
   if (activityProgress?.isCompleted && !activityProgress?.isSuccess) {
     return (
       <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-foreground/10">
-        <RotateCcw className="h-3 w-3 text-foreground/40" />
+        <RotateCcw className="h-3 w-3 text-foreground/40" aria-hidden="true" />
       </span>
     )
   }
@@ -249,7 +249,7 @@ function StepIndicator({
   }
 
   return (
-    <span className="flex h-5 w-5 shrink-0 items-center justify-center text-[11px] tabular-nums text-muted-foreground/60">
+    <span className="flex h-5 w-5 shrink-0 items-center justify-center text-xs tabular-nums text-muted-foreground/60">
       {index + 1}
     </span>
   )
@@ -292,7 +292,7 @@ function ActivityItem({
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <span
           className={cn(
-            'text-[13px] leading-snug',
+            'text-sm leading-snug',
             isCurrent
               ? 'font-medium text-foreground'
               : activityProgress?.isCompleted
@@ -303,11 +303,11 @@ function ActivityItem({
           {activity.title}
         </span>
         <div className="flex items-center gap-2">
-          <span className="text-[11px] text-muted-foreground/60">
+          <span className="text-xs text-muted-foreground/60">
             {TYPE_LABELS[activity.type]}
           </span>
           {activity.timeMinutes > 0 && (
-            <span className="text-[11px] text-muted-foreground/40">
+            <span className="text-xs text-muted-foreground/40">
               {formatDuration(activity.timeMinutes)}
             </span>
           )}
@@ -317,7 +317,7 @@ function ActivityItem({
             activityProgress?.total !== undefined && (
               <span
                 className={cn(
-                  'text-[11px] tabular-nums',
+                  'text-xs tabular-nums',
                   activityProgress.isSuccess
                     ? 'text-muted-foreground/60'
                     : 'font-medium text-foreground/50'
@@ -354,10 +354,10 @@ function SectionAccordion({
     <AccordionItem value={section.id} className="border-none">
       <AccordionTrigger className="px-4 py-2.5 hover:bg-muted/50 hover:no-underline [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:text-muted-foreground/50">
         <div className="flex flex-1 items-center justify-between pr-2">
-          <span className="text-[13px] font-medium text-foreground">
+          <span className="text-sm font-medium text-foreground">
             {section.label}
           </span>
-          <span className="text-[11px] tabular-nums text-muted-foreground/60">
+          <span className="text-xs tabular-nums text-muted-foreground/60">
             {allDone ? 'Terminé' : `${completed}/${total}`}
           </span>
         </div>
@@ -442,6 +442,7 @@ function TimelineHeader({
               className="h-6 w-6 shrink-0 text-muted-foreground/50 hover:text-muted-foreground"
             >
               <ChevronUp
+                aria-hidden="true"
                 className={cn(
                   'h-3.5 w-3.5 transition-transform duration-200',
                   !isOpen && 'rotate-180'
@@ -457,7 +458,7 @@ function TimelineHeader({
         <CollapsibleContent className="overflow-hidden transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
           <div className="flex flex-col gap-3 pb-1">
             {data.description && (
-              <p className="text-[12px] leading-relaxed text-muted-foreground">
+              <p className="text-xs leading-relaxed text-muted-foreground">
                 {data.description}
               </p>
             )}
@@ -468,25 +469,25 @@ function TimelineHeader({
                 {data.objectives!.map((obj) => (
                   <li
                     key={obj}
-                    className="flex items-start gap-2 text-[12px] text-muted-foreground/80"
+                    className="flex items-start gap-2 text-xs text-muted-foreground/80"
                   >
-                    <Check className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground/40" />
+                    <Check className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground/40" aria-hidden="true" />
                     <span className="leading-relaxed">{obj}</span>
                   </li>
                 ))}
               </ul>
             )}
 
-            <div className="flex items-center gap-3 text-[11px] text-muted-foreground/60">
+            <div className="flex items-center gap-3 text-xs text-muted-foreground/60">
               {/* Difficulty (Serie) */}
               {hasDifficulty && (
                 <span className="flex items-center gap-1">
-                  <Gauge className="h-3 w-3" />
+                  <Gauge className="h-3 w-3" aria-hidden="true" />
                   {DIFFICULTY_LABELS[data.difficulty!] || 'Moyen'}
                 </span>
               )}
               <span className="flex items-center gap-1">
-                <Clock className="h-3 w-3" />
+                <Clock className="h-3 w-3" aria-hidden="true" />
                 {formatDuration(data.estimatedMinutes)}
               </span>
               <span className="tabular-nums">{progressPercent}% terminé</span>
@@ -495,11 +496,11 @@ function TimelineHeader({
             <Button
               variant="ghost"
               size="sm"
-              className="w-full justify-between text-[13px] font-medium text-foreground hover:bg-muted"
+              className="w-full justify-between text-sm font-medium text-foreground hover:bg-muted"
               onClick={onContinue}
             >
               Continuer
-              <ArrowRight className="h-3.5 w-3.5" />
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
             </Button>
           </div>
         </CollapsibleContent>
@@ -507,7 +508,7 @@ function TimelineHeader({
         {/* Progress bar always visible */}
         <div className="flex items-center gap-2.5">
           <Progress value={progressPercent} className="h-1 flex-1" />
-          <span className="text-[11px] tabular-nums text-muted-foreground/50">
+          <span className="text-xs tabular-nums text-muted-foreground/50">
             {progressPercent}%
           </span>
         </div>
@@ -616,12 +617,12 @@ export function CourseTimeline({
         className="fixed left-4 top-4 z-50 h-9 w-9 border-border/50 bg-background/80 backdrop-blur-sm lg:hidden"
         onClick={() => setSheetOpen(true)}
       >
-        <PanelLeft className="h-4 w-4" />
+        <PanelLeft className="h-4 w-4" aria-hidden="true" />
         <span className="sr-only">Ouvrir le menu</span>
       </Button>
 
       <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
-        <SheetContent side="left" className="w-80 p-0 flex flex-col overscroll-contain">
+        <SheetContent side="left" className="w-[min(80vw,320px)] p-0 flex flex-col overscroll-contain">
           <SheetTitle className="sr-only">{data.title}</SheetTitle>
           {timelineContent}
         </SheetContent>

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -66,7 +66,7 @@ export function NavUser() {
         <SidebarMenuItem>
           <SidebarMenuButton asChild>
             <Link href="/login">
-              <CircleUser className="h-4 w-4" />
+              <CircleUser className="h-4 w-4" aria-hidden="true" />
               <span>Se connecter</span>
             </Link>
           </SidebarMenuButton>
@@ -106,7 +106,7 @@ export function NavUser() {
                     {parcoursConfig ? parcoursConfig.label : userEmail}
                   </span>
                 </div>
-                <EllipsisVertical className="ml-auto size-4" />
+                <EllipsisVertical className="ml-auto size-4" aria-hidden="true" />
               </SidebarMenuButton>
             </DropdownMenuTrigger>
             <DropdownMenuContent
@@ -138,16 +138,16 @@ export function NavUser() {
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => openProfile('stats')}>
-                <CircleUser className="mr-2 h-4 w-4" />
+                <CircleUser className="mr-2 h-4 w-4" aria-hidden="true" />
                 Profil
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => openProfile('settings')}>
-                <Settings className="mr-2 h-4 w-4" />
+                <Settings className="mr-2 h-4 w-4" aria-hidden="true" />
                 Paramètres
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => signOut()}>
-                <LogOut className="mr-2 h-4 w-4" />
+                <LogOut className="mr-2 h-4 w-4" aria-hidden="true" />
                 Déconnexion
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/src/components/parcours-banner.tsx
+++ b/src/components/parcours-banner.tsx
@@ -39,22 +39,22 @@ export function ParcoursBanner({ urlParcours }: ParcoursBannerProps) {
   }
 
   return (
-    <Alert className="mx-4 mt-4 border-blue-200 bg-blue-50 lg:mx-6 dark:border-blue-800 dark:bg-blue-950/20">
-      <Info className="h-4 w-4 text-blue-600" />
-      <AlertDescription className="flex flex-wrap items-center gap-x-2 gap-y-1 text-blue-800 dark:text-blue-200">
+    <Alert className="mx-4 mt-4 border-info/25 bg-info/10 lg:mx-6">
+      <Info className="h-4 w-4 text-info" aria-hidden="true" />
+      <AlertDescription className="flex flex-wrap items-center gap-x-2 gap-y-1 text-info-foreground">
         <span>Vous consultez &quot;{urlParcoursConfig.label}&quot;.</span>
-        <span className="text-blue-600 dark:text-blue-400">
+        <span className="text-info">
           Votre parcours : {userParcoursConfig.label}
         </span>
         <Button
           variant="link"
           size="sm"
-          className="h-auto p-0 text-blue-600 dark:text-blue-400"
+          className="h-auto p-0 text-info"
           asChild
         >
           <Link href={`/${userParcours.slug}`}>
             Aller à mon parcours
-            <ArrowRight className="ml-1 h-3 w-3" />
+            <ArrowRight className="ml-1 h-3 w-3" aria-hidden="true" />
           </Link>
         </Button>
       </AlertDescription>

--- a/src/components/patterns/module-card.tsx
+++ b/src/components/patterns/module-card.tsx
@@ -48,7 +48,7 @@ export function ModuleCard({
           />
         ) : (
           <div className="flex h-full items-center justify-center">
-            <BookOpen className="h-12 w-12 text-muted-foreground/50" />
+            <BookOpen className="h-12 w-12 text-muted-foreground/50" aria-hidden="true" />
           </div>
         )}
       </div>

--- a/src/components/patterns/qcm-player.tsx
+++ b/src/components/patterns/qcm-player.tsx
@@ -148,13 +148,13 @@ export function QCMPlayer({
             <div
               className={cn(
                 'mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full',
-                isSuccess ? 'bg-green-100 dark:bg-green-950/30' : 'bg-orange-100 dark:bg-orange-950/30'
+                isSuccess ? 'bg-success/10' : 'bg-warning/10'
               )}
             >
               {isSuccess ? (
-                <Check className="h-8 w-8 text-green-600" />
+                <Check className="h-8 w-8 text-success" aria-hidden="true" />
               ) : (
-                <X className="h-8 w-8 text-orange-600" />
+                <X className="h-8 w-8 text-warning" aria-hidden="true" />
               )}
             </div>
             <h2 className="text-2xl font-bold">
@@ -220,8 +220,8 @@ export function QCMPlayer({
                       : 'hover:border-primary/50 hover:bg-muted/50',
                   ],
                   showResult && [
-                    isCorrect && 'border-green-500 bg-green-50 dark:bg-green-950/20',
-                    isSelected && !isCorrect && 'border-red-500 bg-red-50 dark:bg-red-950/20',
+                    isCorrect && 'border-success bg-success/10',
+                    isSelected && !isCorrect && 'border-destructive bg-destructive/10',
                   ]
                 )}
               >
@@ -234,8 +234,8 @@ export function QCMPlayer({
                         : 'border-muted-foreground/30',
                     ],
                     showResult && [
-                      isCorrect && 'border-green-500 bg-green-500 text-white',
-                      isSelected && !isCorrect && 'border-red-500 bg-red-500 text-white',
+                      isCorrect && 'border-success bg-success text-white',
+                      isSelected && !isCorrect && 'border-destructive bg-destructive text-white',
                     ]
                   )}
                 >
@@ -260,9 +260,9 @@ export function QCMPlayer({
 
         {/* Explanation after validation */}
         {state === 'validated' && currentQuestion.explication && (
-          <div aria-live="polite" className="mt-4 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950/20">
-            <p className="text-sm font-medium text-blue-800 dark:text-blue-200">Explication</p>
-            <div className="mt-1 text-sm text-blue-700 dark:text-blue-300">
+          <div aria-live="polite" className="mt-4 rounded-lg border border-info/25 bg-info/10 p-4">
+            <p className="text-sm font-medium text-info-foreground">Explication</p>
+            <div className="mt-1 text-sm text-info-foreground">
               {currentQuestion.explication}
             </div>
           </div>
@@ -292,7 +292,7 @@ export function QCMPlayer({
           ) : (
             <Button onClick={handleNext}>
               {isLastQuestion ? 'Terminer' : 'Suivant'}
-              <ArrowRight className="ml-2 h-4 w-4" />
+              <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
             </Button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- **100vh → 100svh** : fix iOS Safari viewport overflow (serie-player, layout)
- **aria-hidden** : ajout sur 30+ icônes décoratives Lucide dans 12 fichiers
- **Semantic color tokens** : migration des couleurs hardcodées (green-*, blue-*, red-*, amber-*) vers les tokens sémantiques (success, info, warning, destructive) avec modifieurs d'opacité
- **Typographie** : text-[11px]/[12px] → text-xs, text-[13px] → text-sm dans CourseTimeline pour lisibilité mobile
- **Sheet responsive** : w-80 → w-[min(80vw,320px)] pour petits écrans
- **Skeleton loaders** : remplacement des "Chargement..." par des Skeleton dans les loading.tsx

## Test plan
- [ ] Vérifier le viewport sur iOS Safari (pas de débordement)
- [ ] Vérifier l'accessibilité avec un lecteur d'écran (icônes non annoncées)
- [ ] Vérifier les couleurs sémantiques en light + dark mode
- [ ] Vérifier la taille du texte sur mobile dans la timeline
- [ ] Vérifier le sheet sur petit écran (iPhone SE)
- [ ] Vérifier les skeletons de chargement

🤖 Generated with [Claude Code](https://claude.com/claude-code)