### PR TITLE
feat(C4): enrichissement contenu — graphes interactifs

### DIFF
--- a/content/atoms/lesson-der-variations.mdx
+++ b/content/atoms/lesson-der-variations.mdx
@@ -122,6 +122,8 @@ $$f(1) = 1 - 3 + 1 = -1$$
 
 </Example>
 
+<Graph function="x^3 - 3*x + 1" range="[-3, 3]" yRange="[-4, 6]" />
+
 <Attention title="Erreur fréquente">
 
 Ne pas confondre :

--- a/content/atoms/lesson-fa-sens-variation.mdx
+++ b/content/atoms/lesson-fa-sens-variation.mdx
@@ -62,6 +62,8 @@ On identifie $a = -4 < 0$, donc la fonction est strictement decroissante sur $\m
 
 </Example>
 
+<Graph function="-4*x + 7" range="[-1, 4]" yRange="[-10, 12]" />
+
 <Variations var="x" intervals="[-∞, +∞]">
   <Row label="f(x)" kind="var" values="[+∞, ↘, -∞]" />
 </Variations>

--- a/content/atoms/lesson-fa-signe.mdx
+++ b/content/atoms/lesson-fa-signe.mdx
@@ -64,6 +64,8 @@ Etudier le signe de $f(x) = 2x - 6$.
 
 </Example>
 
+<Graph function="2*x - 6" range="[-1, 7]" yRange="[-8, 8]" />
+
 ### Application aux inequations
 
 <Property title="Resolution d'inequations du premier degre">

--- a/content/atoms/lesson-fl-representation.mdx
+++ b/content/atoms/lesson-fl-representation.mdx
@@ -40,6 +40,10 @@ Pour tracer le graphe d'une fonction lineaire $f(x) = ax$ :
 
 </Example>
 
+<Graph function="2*x" range="[-3, 4]" yRange="[-4, 6]" />
+
+<Graph function="-x" range="[-3, 4]" yRange="[-4, 6]" />
+
 ### Le coefficient directeur
 
 Le coefficient $a$ determine l'**inclinaison** (ou **pente**) de la droite :

--- a/content/atoms/lesson-fn-parite.mdx
+++ b/content/atoms/lesson-fn-parite.mdx
@@ -49,6 +49,8 @@ Donc $f$ est **paire**.
 
 </Example>
 
+<Graph function="x^2 + 1" range="[-3, 3]" yRange="[-1, 10]" />
+
 ### Fonction impaire
 
 <Definition title="Fonction impaire">
@@ -91,6 +93,8 @@ Donc $f$ est **impaire**.
 On verifie bien que $f(0) = 0$.
 
 </Example>
+
+<Graph function="x^3 - x" range="[-2, 2]" yRange="[-2, 2]" />
 
 ### Fonction ni paire ni impaire
 

--- a/content/atoms/lesson-fn-transformations.mdx
+++ b/content/atoms/lesson-fn-transformations.mdx
@@ -152,6 +152,8 @@ Le sommet de $f$ est en $(0, 0)$. Le sommet de $h$ est en $(2, 3)$, et la parabo
 
 </Example>
 
+<Graph function="-(x - 2)^2 + 3" range="[-1, 5]" yRange="[-4, 4]" />
+
 <Attention>
 
 L'ordre des transformations compte ! Par exemple :

--- a/content/atoms/lesson-fn-variations.mdx
+++ b/content/atoms/lesson-fn-variations.mdx
@@ -131,6 +131,8 @@ Il n'y a pas d'extremum local qui ne soit pas global dans cet exemple.
 
 </Example>
 
+<Graph function="x^2" range="[-1, 2]" yRange="[-1, 5]" />
+
 ### Majorant, minorant, borne superieure et inferieure
 
 <Definition title="Majorant et minorant">

--- a/content/atoms/lesson-sys-interpretation-graphique.mdx
+++ b/content/atoms/lesson-sys-interpretation-graphique.mdx
@@ -81,6 +81,10 @@ On a $\frac{1}{2} \neq -2$, donc les droites sont **secantes** et le systeme adm
 
 </Example>
 
+<Graph function="2 - x/2" range="[-1, 5]" yRange="[-2, 5]" />
+
+<Graph function="2*x - 1" range="[-1, 5]" yRange="[-2, 5]" />
+
 <Remark>
 
 L'interpretation graphique est un **outil de visualisation** tres utile pour comprendre la nature des solutions, mais pour obtenir les valeurs exactes, on utilise les methodes algebriques (substitution ou combinaison lineaire).


### PR DESCRIPTION
## Summary

- Audit contenu complet : 422 atomes (89 lecons, 131 exercices, 202 QCMs), 38 series — tout le contenu 1ere-tc est present
- Enrichissement de 8 lecons avec des composants `<Graph>` interactifs :
  - `lesson-fn-parite` : graphes de x²+1 (paire) et x³-x (impaire) pour visualiser la symetrie
  - `lesson-fn-variations` : graphe de x² montrant min/max sur [-1,2]
  - `lesson-fn-transformations` : graphe de -(x-2)²+3 (composition de transformations)
  - `lesson-fa-sens-variation` : graphe de -4x+7 (decroissante)
  - `lesson-fa-signe` : graphe de 2x-6 (racine et signe)
  - `lesson-fl-representation` : graphes de 2x et -x (droites par l'origine)
  - `lesson-der-variations` : graphe de x³-3x+1 (max local en -1, min local en 1)
  - `lesson-sys-interpretation-graphique` : graphes des deux droites du systeme

## Hypotheses prises

- Le contenu 1ere-tc etant deja complet (349 atomes references, tous existants), l'enrichissement s'est concentre sur l'ajout de visualisations interactives plutot que sur la creation de nouveaux atomes
- Les 38 series existantes couvrent deja les besoins du roadmap (objectif etait 25-40)
- Le composant Graph ne supportant qu'une seule fonction, les graphes multi-fonctions utilisent deux `<Graph>` separes

## Test plan

- [x] `npm run build` passe sans erreurs
- [ ] Verifier visuellement chaque lecon enrichie dans le navigateur
- [ ] Confirmer que les graphes s'affichent correctement sur mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)