### PR TITLE
feat(C5): Mobile & PWA — install prompt, offline, timeline fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ public/sw.js
 public/sw.js.map
 public/workbox-*.js
 public/workbox-*.js.map
+public/fallback-*.js
+public/fallback-*.js.map
 
 # vercel
 .vercel

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,9 @@ const withPWA = withPWAInit({
   disable: process.env.NODE_ENV === 'development',
   register: true,
   skipWaiting: true,
+  fallbacks: {
+    document: '/offline',
+  },
 })
 
 const nextConfig: NextConfig = {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css'
 import { QueryProvider } from '@/lib/query/provider'
 import { AuthProvider } from '@/lib/context'
 import { Toaster } from '@/components/ui/sonner'
+import { PwaInstallPrompt } from '@/components/pwa-install-prompt'
 
 const dmSans = DM_Sans({
   variable: '--font-dm-sans',
@@ -56,6 +57,7 @@ export default function RootLayout({
           <AuthProvider>
             {children}
             <Toaster />
+            <PwaInstallPrompt />
           </AuthProvider>
         </QueryProvider>
       </body>

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+/**
+ * Offline Fallback Page
+ *
+ * Shown when the user is offline and the requested page is not cached.
+ * Registered as the PWA offline fallback via next-pwa configuration.
+ */
+
+import { WifiOff } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+
+export default function OfflinePage() {
+  return (
+    <div className="flex min-h-svh items-center justify-center px-4">
+      <Card className="w-full max-w-md text-center">
+        <CardContent className="py-12">
+          <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+            <WifiOff className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
+          </div>
+          <h1 className="font-serif text-2xl font-semibold">Hors connexion</h1>
+          <p className="mt-2 text-muted-foreground">
+            Vous n&apos;êtes pas connecté à Internet. Vérifiez votre connexion et réessayez.
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Les pages déjà visitées restent disponibles hors ligne.
+          </p>
+          <Button
+            className="mt-6"
+            onClick={() => {
+              if (typeof window !== 'undefined') {
+                window.location.reload()
+              }
+            }}
+          >
+            Réessayer
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/components/course-timeline.tsx
+++ b/src/components/course-timeline.tsx
@@ -614,7 +614,7 @@ export function CourseTimeline({
       <Button
         variant="outline"
         size="icon"
-        className="fixed left-4 top-4 z-50 h-9 w-9 border-border/50 bg-background/80 backdrop-blur-sm lg:hidden"
+        className="fixed left-4 top-16 z-50 h-9 w-9 border-border/50 bg-background/80 backdrop-blur-sm lg:hidden"
         onClick={() => setSheetOpen(true)}
       >
         <PanelLeft className="h-4 w-4" aria-hidden="true" />

--- a/src/components/pwa-install-prompt.tsx
+++ b/src/components/pwa-install-prompt.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+/**
+ * PWA Install Prompt
+ *
+ * Shows a dismissible banner suggesting the user install the app on their home screen.
+ * Uses the `beforeinstallprompt` event for Chrome/Edge and falls back to
+ * instructions for iOS Safari.
+ */
+
+import * as React from 'react'
+import { Download, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
+const DISMISSED_KEY = 'pwa-install-dismissed'
+
+export function PwaInstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = React.useState<BeforeInstallPromptEvent | null>(null)
+  const [showPrompt, setShowPrompt] = React.useState(false)
+  const [isIos, setIsIos] = React.useState(false)
+
+  React.useEffect(() => {
+    // Don't show if already dismissed or already installed
+    if (sessionStorage.getItem(DISMISSED_KEY)) return
+    if (window.matchMedia('(display-mode: standalone)').matches) return
+
+    // Detect iOS
+    const ua = navigator.userAgent
+    const isIosDevice = /iPad|iPhone|iPod/.test(ua) && !('MSStream' in window)
+    setIsIos(isIosDevice)
+
+    // Listen for the install prompt (Chrome/Edge)
+    const handler = (e: Event) => {
+      e.preventDefault()
+      setDeferredPrompt(e as BeforeInstallPromptEvent)
+      setShowPrompt(true)
+    }
+
+    window.addEventListener('beforeinstallprompt', handler)
+
+    // For iOS, show the prompt after a delay (no beforeinstallprompt event)
+    if (isIosDevice) {
+      const timer = setTimeout(() => setShowPrompt(true), 3000)
+      return () => {
+        clearTimeout(timer)
+        window.removeEventListener('beforeinstallprompt', handler)
+      }
+    }
+
+    return () => window.removeEventListener('beforeinstallprompt', handler)
+  }, [])
+
+  const handleInstall = async () => {
+    if (!deferredPrompt) return
+    await deferredPrompt.prompt()
+    const { outcome } = await deferredPrompt.userChoice
+    if (outcome === 'accepted') {
+      setShowPrompt(false)
+    }
+    setDeferredPrompt(null)
+  }
+
+  const handleDismiss = () => {
+    setShowPrompt(false)
+    sessionStorage.setItem(DISMISSED_KEY, '1')
+  }
+
+  if (!showPrompt) return null
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 p-4 sm:p-6">
+      <Card className="mx-auto max-w-md border-primary/20 bg-background shadow-lg">
+        <CardContent className="flex items-start gap-3 py-4">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            <Download className="h-5 w-5 text-primary" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium">Installer l&apos;application</p>
+            {isIos ? (
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                Appuyez sur le bouton Partager puis &quot;Sur l&apos;écran d&apos;accueil&quot;
+              </p>
+            ) : (
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                Accédez à vos cours même hors connexion
+              </p>
+            )}
+            {!isIos && deferredPrompt && (
+              <Button size="sm" className="mt-2" onClick={handleInstall}>
+                Installer
+              </Button>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0"
+            onClick={handleDismiss}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+            <span className="sr-only">Fermer</span>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Offline fallback page** (`/offline`): page avec icone WifiOff, message clair, et bouton "Réessayer" quand l'utilisateur est hors ligne et la page n'est pas en cache
- **PWA install prompt**: banniere flottante en bas d'ecran invitant a installer l'app
  - Chrome/Edge: utilise `beforeinstallprompt` avec bouton "Installer"
  - iOS Safari: affiche des instructions "Partager > Sur l'ecran d'accueil"
  - Dismissible par session (sessionStorage)
  - Ne s'affiche pas si l'app est deja installee (standalone mode)
- **Timeline button fix**: le bouton flottant mobile (PanelLeft) chevauchait le header a `top-4` (16px) — corrige a `top-16` (64px) pour etre en dessous du header (56px)
- **Gitignore**: ajout des fichiers `fallback-*.js` generes par next-pwa

## Hypotheses prises

- C5.2 (corrections UX mobile) etait deja traite dans C3 (100svh, typographie, sheet width) — seul le chevauchement timeline/header restait
- C5.3 (Scan) et C5.4 (Analytics) sont marques optionnels dans le roadmap — non implementes
- Le PWA install prompt utilise `sessionStorage` au lieu de `localStorage` pour ne pas etre trop insistant (re-apparait a chaque session si pas installe)
- La page offline est un client component pour le bouton "Réessayer" (window.location.reload)

## Test plan

- [x] `npm run type-check` passe
- [x] `npm run build` passe (route `/offline` statiquement prerendue)
- [ ] Tester la page offline en coupant le reseau dans DevTools
- [ ] Tester le install prompt sur Chrome mobile
- [ ] Verifier que le bouton timeline ne chevauche plus le header sur mobile
- [ ] Verifier que le prompt ne s'affiche pas en mode standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)